### PR TITLE
GitHub Forth language recognition

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.HSF linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this if you'd like GitHub to recognize your `.HSF` and `.TXT` files as Forth.